### PR TITLE
ignore reporter out  if none

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
     name: Test Suite
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
         rust: [stable]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,7 @@ on:
   push:
     branches:
       - master
-  schedule:
-    - cron: '00 01 * * *'
+
 env:
   CLICOLOR_FORCE: 1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,7 +65,7 @@ checksum = "44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.76",
 ]
 
 [[package]]
@@ -84,7 +93,7 @@ checksum = "e7a905d892734eea339e896738c14b9afce22b5318f64b951e70bf3844419b01"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
@@ -107,10 +116,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
-name = "bit-set"
-version = "0.5.2"
+name = "base64"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
  "bit-vec",
 ]
@@ -150,21 +165,15 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cc"
 version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -243,18 +252,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
 dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
-dependencies = [
- "autocfg",
- "cfg-if 0.1.10",
- "lazy_static",
+ "cfg-if",
 ]
 
 [[package]]
@@ -280,13 +278,13 @@ dependencies = [
 
 [[package]]
 name = "derive-getters"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c5905670fd9c320154f3a4a01c9e609733cd7b753f3c58777ab7d5ce26686b3"
+checksum = "0122f262bf9c9a367829da84f808d9fb128c10ef283bbe7b0922a77cf07b2747"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.76",
 ]
 
 [[package]]
@@ -310,7 +308,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "dirs-sys-next",
 ]
 
@@ -343,21 +341,14 @@ version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.9.0"
+name = "equivalent"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "error-chain"
@@ -370,12 +361,13 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.7.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6b8560a05112eb52f04b00e5d3790c0dd75d9d980eb8a122fb23b92a623ccf"
+checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
 dependencies = [
  "bit-set",
- "regex",
+ "regex-automata",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -467,7 +459,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.76",
 ]
 
 [[package]]
@@ -519,9 +511,9 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.10.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -541,11 +533,30 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
- "indexmap",
+ "http 0.2.5",
+ "indexmap 1.7.0",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.8",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "816ec7294445779408f36fe57bc5b7fc1cf59664059096c65f905c1c61f58069"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 1.1.0",
+ "indexmap 2.2.6",
+ "slab",
+ "tokio",
+ "tokio-util 0.7.11",
  "tracing",
 ]
 
@@ -554,6 +565,12 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hermit-abi"
@@ -594,7 +611,18 @@ checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
 dependencies = [
  "bytes",
  "fnv",
- "itoa",
+ "itoa 0.4.8",
+]
+
+[[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa 1.0.11",
 ]
 
 [[package]]
@@ -604,27 +632,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "399c583b2979440c60be0821a6199eca73bc3c8dcd9d070d75ac726e2c6186e5"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.5",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.5.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "httpdate"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -636,17 +681,37 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.4",
+ "http 0.2.5",
+ "http-body 0.4.3",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 0.4.8",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.2",
  "tokio",
  "tower-service",
  "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.4",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "httparse",
+ "itoa 1.0.11",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
  "want",
 ]
 
@@ -657,10 +722,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.13",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.3.1",
+ "pin-project-lite",
+ "socket2 0.5.7",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -681,7 +782,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.11.2",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -695,6 +806,12 @@ name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
@@ -726,9 +843,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.102"
+version = "0.2.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a5ac8f984bfcf3a823267e5fde638acc3325f6496633a5da6bb6eb2171e103"
+checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
 
 [[package]]
 name = "linked-hash-map"
@@ -738,12 +855,9 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
-dependencies = [
- "cfg-if 1.0.0",
-]
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "maplit"
@@ -770,9 +884,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "mime"
@@ -792,24 +906,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.13"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
- "log",
- "miow",
- "ntapi",
- "winapi",
-]
-
-[[package]]
-name = "miow"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
-dependencies = [
- "winapi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -832,9 +935,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.8"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
 dependencies = [
  "lazy_static",
  "libc",
@@ -856,15 +959,6 @@ checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 dependencies = [
  "memchr",
  "version_check 0.1.5",
-]
-
-[[package]]
-name = "ntapi"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -918,9 +1012,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opaque-debug"
@@ -938,7 +1032,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "serde_yaml",
+ "serde_yaml 0.7.5",
 ]
 
 [[package]]
@@ -948,7 +1042,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d9facdb76fec0b73c406f125d44d86fdad818d66fef0531eec9233ca425ff4a"
 dependencies = [
  "bitflags",
- "cfg-if 1.0.0",
+ "cfg-if",
  "foreign-types",
  "libc",
  "once_cell",
@@ -981,10 +1075,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
-name = "pin-project-lite"
-version = "0.2.7"
+name = "pin-project"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.61",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -1018,18 +1132,18 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.29"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
+checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -1099,9 +1213,20 @@ version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
- "aho-corasick",
+ "aho-corasick 0.7.18",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.6.25",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+dependencies = [
+ "aho-corasick 1.1.3",
+ "memchr",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -1109,6 +1234,12 @@ name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "remove_dir_all"
@@ -1121,32 +1252,40 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.4"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246e9f61b9bb77df069a947682be06e31ac43ea37862e244a69f177694ea6d22"
+checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
- "hyper",
- "hyper-tls",
+ "h2 0.4.4",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-tls 0.6.0",
+ "hyper-util",
  "ipnet",
  "js-sys",
- "lazy_static",
  "log",
  "mime",
  "native-tls",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -1156,18 +1295,18 @@ dependencies = [
 
 [[package]]
 name = "rusoto_core"
-version = "0.47.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b4f000e8934c1b4f70adde180056812e7ea6b1a247952db8ee98c94cd3116cc"
+checksum = "1db30db44ea73551326269adcf7a2169428a054f14faf9e1768f2163494f2fa2"
 dependencies = [
  "async-trait",
  "base64 0.13.0",
  "bytes",
  "crc32fast",
  "futures",
- "http",
- "hyper",
- "hyper-tls",
+ "http 0.2.5",
+ "hyper 0.14.13",
+ "hyper-tls 0.5.0",
  "lazy_static",
  "log",
  "rusoto_credential",
@@ -1181,15 +1320,15 @@ dependencies = [
 
 [[package]]
 name = "rusoto_credential"
-version = "0.47.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a46b67db7bb66f5541e44db22b0a02fed59c9603e146db3a9e633272d3bac2f"
+checksum = "ee0a6c13db5aad6047b6a44ef023dbbc21a056b6dab5be3b79ce4283d5c02d05"
 dependencies = [
  "async-trait",
  "chrono",
  "dirs-next",
  "futures",
- "hyper",
+ "hyper 0.14.13",
  "serde",
  "serde_json",
  "shlex",
@@ -1199,9 +1338,9 @@ dependencies = [
 
 [[package]]
 name = "rusoto_signature"
-version = "0.47.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6264e93384b90a747758bcc82079711eacf2e755c3a8b5091687b5349d870bcc"
+checksum = "a5ae95491c8b4847931e291b151127eccd6ff8ca13f33603eb3d0035ecb05272"
 dependencies = [
  "base64 0.13.0",
  "bytes",
@@ -1210,8 +1349,8 @@ dependencies = [
  "futures",
  "hex",
  "hmac",
- "http",
- "hyper",
+ "http 0.2.5",
+ "hyper 0.14.13",
  "log",
  "md-5",
  "percent-encoding",
@@ -1246,6 +1385,22 @@ checksum = "fe8c976e50876cb3423699b190e799ff4c8a1a4f47dc33f4036dd056c077b7bb"
 dependencies = [
  "nom",
 ]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+dependencies = [
+ "base64 0.22.1",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "ryu"
@@ -1294,22 +1449,22 @@ checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "serde"
-version = "1.0.130"
+version = "1.0.201"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+checksum = "780f1cebed1629e4753a1a38a3c72d30b97ec044f0aef68cb26650a3c5cf363c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.130"
+version = "1.0.201"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+checksum = "c5e405930b9796f1c00bee880d03fc7e0bb4b9a11afc776885ffe84320da2865"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -1318,19 +1473,19 @@ version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
 dependencies = [
- "itoa",
+ "itoa 0.4.8",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "serde_urlencoded"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa",
+ "itoa 1.0.11",
  "ryu",
  "serde",
 ]
@@ -1348,15 +1503,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.2.6",
+ "itoa 1.0.11",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "service_policy_kit"
 version = "0.7.0"
 dependencies = [
  "anyhow",
- "atty",
  "chrono",
  "console",
  "difference",
- "env_logger",
  "fancy-regex",
  "histogram",
  "junit-report",
@@ -1370,7 +1536,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "serde_yaml",
+ "serde_yaml 0.9.34+deprecated",
  "subprocess",
  "x509-parser",
 ]
@@ -1382,7 +1548,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
 dependencies = [
  "block-buffer",
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest",
  "opaque-debug",
@@ -1410,6 +1576,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
 
 [[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
 name = "socket2"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1417,6 +1589,16 @@ checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1430,11 +1612,10 @@ dependencies = [
 
 [[package]]
 name = "subprocess"
-version = "0.1.20"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68713fc0f9d941642c1e020d622e6421dfe09e8891ddd4bfa2109fda9a40431d"
+checksum = "0c2e86926081dda636c546d8c5e641661049d7562a68f5488be4a1f7f66f6086"
 dependencies = [
- "crossbeam-utils",
  "libc",
  "winapi",
 ]
@@ -1457,26 +1638,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c993ed8ccba56ae856363b1845da7266a7cb78e1d146c8a32d54b45a8b831fc9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "rand",
  "redox_syscall",
  "remove_dir_all",
  "winapi",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -1491,22 +1701,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.29"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
+checksum = "579e9083ca58dd9dcf91a9923bb9054071b9ebbd800b342194c9feb0ee89fc18"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.29"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
+checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -1516,7 +1726,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
@@ -1537,32 +1747,31 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.12.0"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
- "autocfg",
+ "backtrace",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
- "once_cell",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2 0.5.7",
  "tokio-macros",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.61",
 ]
 
 [[package]]
@@ -1590,6 +1799,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
 name = "tower-service"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1597,22 +1841,22 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.28"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84f96e095c0c82419687c20ddf5cb3eadb61f4e1405923c9dc8e53a1adacbda8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if 1.0.0",
+ "log",
  "pin-project-lite",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.20"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46125608c26121c81b0c6d693eab5a420e416da7e43c426d2e8f7df8da8a3acf"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
@@ -1634,6 +1878,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085"
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
 name = "unicode-normalization"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1644,15 +1894,21 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.9"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
 
 [[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "url"
@@ -1728,14 +1984,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
 dependencies = [
- "cfg-if 1.0.0",
- "serde",
- "serde_json",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 
@@ -1750,7 +2010,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.76",
  "wasm-bindgen-shared",
 ]
 
@@ -1760,7 +2020,7 @@ version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -1784,7 +2044,7 @@ checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.76",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1822,27 +2082,158 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "winreg"
-version = "0.7.0"
+name = "windows-sys"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "winapi",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "service_policy_kit"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,28 +11,27 @@ description = "A toolkit to verify services against security policies"
 name = "service_policy_kit"
 
 [dependencies]
-reqwest={version = "0.11.4", features=["blocking", "json"] }
-serde="1"
-serde_json="1"
-serde_derive="1"
-serde_yaml="0.7.5"
-fancy-regex="0.7.1"
-log="0.4.14"
-env_logger="0.9.0"
-histogram="0.6.9"
-atty="0.2.14"
-native-tls = "0.2.8"
-x509-parser = "0.4.1"
-chrono = "0.4.6"
-junit-report="0.6.0"
-subprocess = "0.1.18"
-difference = "2.0.0"
-openapi = "0.1.5"
-anyhow = "1.0.44"
-console = "0.14.1"
-maplit="1.0.2"
-rusoto_core = "0.47.0"
+reqwest = { version = "0.12.4", features = ["blocking", "json"] }
+serde = { version = "1" }
+serde_json = { version = "1" }
+serde_derive = { version = "1" }
+serde_yaml = { version = "0.9" }
+fancy-regex = { version = "0.13.0" }
+log = { version = "0.4.14" }
+# env_logger = { version = "0.9.0" }
+histogram = { version = "0.6.9" }
+# atty = { version = "0.2.14" }
+native-tls = { version = "0.2.8" }
+x509-parser = { version = "0.4.1" }
+chrono = { version = "0.4.6" }
+junit-report = { version = "0.6.0" }
+subprocess = { version = "0.2.9" }
+difference = { version = "2.0.0" }
+openapi = { version = "0.1.5" }
+anyhow = { version = "1.0.44" }
+console = { version = "0.14.1" }
+maplit = { version = "1.0.2" }
+rusoto_core = { version = "0.48.0" }
 
 [dev-dependencies]
 mockito = "0.30.0"
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "service_policy_kit"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Dotan Nahum <jondotan@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -1,6 +1,5 @@
 use crate::data::{Cause, Check, CheckResult, Context, Interaction, Sender, Violation};
 use histogram::Histogram;
-use log::*;
 use std::time::{Duration, Instant};
 pub struct Bench<'a> {
     sender: &'a dyn Sender,
@@ -36,7 +35,7 @@ impl<'a> Check for Bench<'a> {
 
             let inter = prepared.ok().unwrap();
             for _ in 0..benchmark.times {
-                debug!("Bench request: {:?}", &inter.request);
+                log::debug!("Bench request: {:?}", &inter.request);
                 let now = Instant::now();
                 let res = inter.send(self.sender);
                 match res {
@@ -67,7 +66,7 @@ impl<'a> Check for Bench<'a> {
                     subject: "p95".to_string(),
                     wire: Some(p95.to_string()),
                     recorded: benchmark.p95_ms.to_string(),
-                })
+                });
             }
             // verify matching before considering as bench candidate
             let p99 = h.percentile(99.0).unwrap();
@@ -79,7 +78,7 @@ impl<'a> Check for Bench<'a> {
                     subject: "p99".to_string(),
                     wire: Some(p99.to_string()),
                     recorded: benchmark.p99_ms.to_string(),
-                })
+                });
             }
 
             let avg = h.mean().unwrap();
@@ -91,7 +90,7 @@ impl<'a> Check for Bench<'a> {
                     subject: "avg".to_string(),
                     wire: Some(avg.to_string()),
                     recorded: benchmark.avg_ms.to_string(),
-                })
+                });
             }
 
             if total > u128::from(benchmark.time_ms) {
@@ -102,7 +101,7 @@ impl<'a> Check for Bench<'a> {
                     subject: "time".to_string(),
                     wire: Some(total.to_string()),
                     recorded: benchmark.time_ms.to_string(),
-                })
+                });
             }
 
             CheckResult {

--- a/src/cert.rs
+++ b/src/cert.rs
@@ -8,26 +8,24 @@ use std::time::Instant;
 use fancy_regex::Regex;
 use x509_parser::parse_x509_der;
 pub const NAME: &str = "cert";
+
+#[derive(Default)]
 pub struct Cert {}
 
-impl Default for Cert {
-    fn default() -> Self {
-        Self {}
-    }
-}
 impl Cert {
+    #[must_use]
     pub fn new() -> Self {
-        Cert::default()
+        Self::default()
     }
 }
-fn error_violation(err: String) -> Vec<Violation> {
+fn error_violation(err: &str) -> Vec<Violation> {
     vec![Violation {
         kind: NAME.to_string(),
         cause: Cause::Error,
         on: Some("response".to_string()),
         subject: "request".to_string(),
-        wire: Some(format!("error: {}", err)),
-        recorded: "".to_string(),
+        wire: Some(format!("error: {err}")),
+        recorded: String::new(),
     }]
 }
 impl Check for Cert {
@@ -45,7 +43,7 @@ impl Check for Cert {
                     return CheckResult {
                         kind: NAME.to_string(),
                         request: inter.request.clone(),
-                        violations: error_violation(format!("{}", err)),
+                        violations: error_violation(&err.to_string()),
                         response: None,
                         duration: Some(now.elapsed()),
                         error: Some(err.to_string()),
@@ -63,7 +61,7 @@ impl Check for Cert {
                             return CheckResult {
                                 kind: NAME.to_string(),
                                 request: inter.request.clone(),
-                                violations: error_violation(format!("{}", err)),
+                                violations: error_violation(&err.to_string()),
                                 response: None,
                                 duration: Some(now.elapsed()),
                                 error: None,
@@ -77,7 +75,7 @@ impl Check for Cert {
                     return CheckResult {
                         kind: NAME.to_string(),
                         request: inter.request.clone(),
-                        violations: error_violation(format!("{}", err)),
+                        violations: error_violation(&err.to_string()),
                         response: None,
                         duration: Some(now.elapsed()),
                         error: Some(err.to_string()),

--- a/src/content.rs
+++ b/src/content.rs
@@ -3,6 +3,8 @@ use std::time::Instant;
 use crate::data::{Check, CheckResult, Context, Interaction, Sender};
 use crate::matcher::RegexMatcher;
 pub const NAME: &str = "content";
+
+#[allow(clippy::module_name_repetitions)]
 pub struct ContentCheck<'a> {
     sender: &'a dyn Sender,
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,7 +1,8 @@
 use crate::vars::extract;
 use anyhow::anyhow;
 use anyhow::Result as AnyResult;
-use log::*;
+use log::{debug, error};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::time::Duration;
 use subprocess::{Popen, PopenConfig, Redirection};
@@ -160,7 +161,7 @@ pub struct Context {
 }
 impl Default for Context {
     fn default() -> Self {
-        Context {
+        Self {
             vars_bag: HashMap::new(),
             response_bag: HashMap::new(),
             config: Config { var_braces: None },
@@ -168,22 +169,17 @@ impl Default for Context {
     }
 }
 impl Context {
+    #[must_use]
     pub fn new() -> Self {
-        Context::default()
+        Self::default()
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct Runner {
     pub exit_on_failure: bool,
 }
-impl Default for Runner {
-    fn default() -> Runner {
-        Runner {
-            exit_on_failure: false,
-        }
-    }
-}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SequenceInteractions {
     pub http_interactions: Vec<Interaction>,
@@ -204,14 +200,15 @@ pub struct Interaction {
     pub cert: Option<CertificateDetail>,
 }
 impl Interaction {
-    pub fn sequence_interactions_from_yaml(content: &str) -> AnyResult<Vec<Interaction>> {
+    pub fn sequence_interactions_from_yaml(content: &str) -> AnyResult<Vec<Self>> {
         let result: SequenceInteractions = serde_yaml::from_str(content)?;
         Ok(result.http_interactions)
     }
-    pub fn from_yaml(content: &str) -> AnyResult<Interaction> {
+    pub fn from_yaml(content: &str) -> AnyResult<Self> {
         let result = serde_yaml::from_str(content)?;
         Ok(result)
     }
+    #[must_use]
     pub fn types(&self) -> Vec<&str> {
         let mut v = vec![];
         if self.benchmark.is_some() {
@@ -237,14 +234,15 @@ impl Interaction {
         let responses = &context.response_bag;
         let response_vars = &context.vars_bag;
 
-        let mut vars: HashMap<String, String> = if let Some(command) = &req.vars_command {
-            get_vars_from_cmd(command, &req, responses)
-        } else {
-            HashMap::new()
-        };
-        response_vars.iter().for_each(|(k, v)| {
+        let mut vars: HashMap<String, String> = req
+            .vars_command
+            .as_ref()
+            .map_or_else(HashMap::new, |command| {
+                get_vars_from_cmd(command, &req, responses)
+            });
+        for (k, v) in response_vars {
             vars.insert(k.to_string(), v.to_string());
-        });
+        }
 
         req.uri = render_with_vars(req.uri.clone(), &vars, &fmtstring);
         req.uri_list = req.uri_list.map(|uri_list| {
@@ -256,7 +254,7 @@ impl Interaction {
         if let Some(basic) = req.basic_auth.as_mut() {
             basic.user = render_with_vars(basic.user.clone(), &vars, &fmtstring);
             if let Some(password) = basic.password.as_ref() {
-                basic.password = Some(render_with_vars(password.clone(), &vars, &fmtstring))
+                basic.password = Some(render_with_vars(password.clone(), &vars, &fmtstring));
             }
         }
 
@@ -296,12 +294,13 @@ impl Interaction {
         res.request = req;
         Ok(res)
     }
+
     pub fn send(&self, sender: &dyn Sender) -> AnyResult<Response> {
         let mut resp = sender.send(self)?;
 
         if let Some(vars) = &self.request.vars {
-            let response_vars = extract(&resp, vars);
-            resp.vars = Some(response_vars)
+            let response_vars = extract(&resp, vars)?;
+            resp.vars = Some(response_vars);
         }
 
         Ok(resp)

--- a/src/data.rs
+++ b/src/data.rs
@@ -262,6 +262,14 @@ impl Interaction {
             aws.key = render_with_vars(aws.key.clone(), &vars, &fmtstring);
             aws.secret = render_with_vars(aws.secret.clone(), &vars, &fmtstring);
             aws.service = render_with_vars(aws.service.clone(), &vars, &fmtstring);
+            if let Some(token) = &aws.token {
+                let render_value = render_with_vars(token.clone(), &vars, &fmtstring);
+                if &render_value == token {
+                    aws.token = None;
+                } else {
+                    aws.token = Some(render_value);
+                }
+            }
             aws.region = aws
                 .region
                 .as_ref()
@@ -321,7 +329,7 @@ impl Interaction {
         if let Some(params) = self.request.params.as_ref() {
             let missing_params = params
                 .iter()
-                .filter(|p| !context.vars_bag.contains_key(&p.name))
+                .filter(|p| !context.vars_bag.contains_key(&p.name) && !p.optional)
                 .collect::<Vec<_>>();
             if !missing_params.is_empty() {
                 return Err(anyhow!(
@@ -358,6 +366,8 @@ pub struct CertificateDetail {
 pub struct Param {
     pub name: String,
     pub desc: String,
+    #[serde(default)]
+    pub optional: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -373,6 +383,7 @@ pub struct AWSAuth {
     pub service: String,
     pub key: String,
     pub secret: String,
+    pub token: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/discovery/open_api.rs
+++ b/src/discovery/open_api.rs
@@ -11,7 +11,8 @@ pub struct OpenAPI {
 }
 
 impl OpenAPI {
-    pub fn new(opts: HashMap<String, String>) -> Self {
+    #[must_use]
+    pub const fn new(opts: HashMap<String, String>) -> Self {
         Self { opts }
     }
     // XXX 'top' is not used
@@ -20,7 +21,7 @@ impl OpenAPI {
             Ok(spec) => spec
                 .paths
                 .iter()
-                .map(|(path, item)| {
+                .filter_map(|(path, item)| {
                     let verb = if item.get.is_some() {
                         "get"
                     } else if item.post.is_some() {
@@ -39,7 +40,7 @@ impl OpenAPI {
                             basic_auth: None,
                             aws_auth: None,
                             form: None,
-                            uri: format!("http://{{{{host}}}}{}", path),
+                            uri: format!("http://{{{{host}}}}{path}"),
                             id: None,
                             desc: None,
                             timeout_ms: None,
@@ -62,7 +63,6 @@ impl OpenAPI {
                         examples: None,
                     })
                 })
-                .flatten()
                 .collect::<Vec<_>>(),
             Err(_e) => vec![], // XXX not used
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,3 @@
-#[macro_use]
-extern crate serde_derive;
-extern crate serde;
-extern crate serde_yaml;
-
-extern crate env_logger;
-
-extern crate histogram;
 extern crate log;
 extern crate reqwest;
 pub mod bench;
@@ -76,7 +68,7 @@ mod tests {
             .create();
         let _m2 = mock("GET", "/joe").with_body("hello, joe").create();
         let results = run_interactions(ITC_JSON);
-        println!("{:?}", results);
+        println!("{results:?}");
         assert_eq!(results.len(), 0);
     }
 
@@ -89,7 +81,7 @@ mod tests {
             .with_body("hello, erlang")
             .create();
         let results = run_interactions(ITC_WITH_DEFAULTS);
-        println!("{:?}", results);
+        println!("{results:?}");
         assert_eq!(results.len(), 0);
     }
 }

--- a/src/reporters/json_output.rs
+++ b/src/reporters/json_output.rs
@@ -1,4 +1,5 @@
 use crate::data::{CheckResult, Interaction, ReporterConfig, ReporterOutput};
+use serde::Serialize;
 use serde_json;
 
 #[derive(Serialize)]
@@ -10,15 +11,15 @@ pub struct JsonOutput {}
 unsafe impl Sync for JsonOutput {}
 
 impl JsonOutput {
-    pub fn new(_config: &ReporterConfig) -> JsonOutput {
-        JsonOutput {}
+    pub const fn new(_config: &ReporterConfig) -> Self {
+        Self {}
     }
 }
 impl ReporterOutput for JsonOutput {
     fn end(&mut self, interactions: &[Interaction], results: &[CheckResult]) {
         println!(
             "{}",
-            serde_json::to_value(&EndEvent {
+            serde_json::to_value(EndEvent {
                 interactions,
                 results,
             })

--- a/src/reporters/junit_output.rs
+++ b/src/reporters/junit_output.rs
@@ -7,8 +7,8 @@ pub struct JUnitOutput {
 unsafe impl Sync for JUnitOutput {}
 
 impl JUnitOutput {
-    pub fn new(config: &ReporterConfig) -> JUnitOutput {
-        JUnitOutput {
+    pub fn new(config: &ReporterConfig) -> Self {
+        Self {
             config: config.clone(),
         }
     }
@@ -17,7 +17,7 @@ impl ReporterOutput for JUnitOutput {
     fn end(&mut self, _interactions: &[Interaction], results: &[CheckResult]) {
         let mut suite = TestSuite::new("Violation Checks");
         let mut cases = vec![];
-        results.iter().for_each(|res| {
+        for res in results {
             let success = res.violations.is_empty();
             let test_name = format!("[{}] {}", res.kind, res.request.get_id());
             if success {
@@ -33,8 +33,8 @@ impl ReporterOutput for JUnitOutput {
                     serde_yaml::to_string(&res.violations).unwrap().as_str(),
                 ));
             }
-        });
-        suite.add_testcases(cases.into_iter());
+        }
+        suite.add_testcases(cases);
         let mut junit_report = Report::new();
         junit_report.add_testsuite(suite);
         let mut out: Vec<u8> = Vec::new();
@@ -45,8 +45,8 @@ impl ReporterOutput for JUnitOutput {
         if !std::path::Path::new(pref).exists() {
             fs::create_dir(pref).unwrap();
         }
-        let f = format!("{}/junit.xml", pref);
-        println!("wrote: {}", f);
+        let f = format!("{pref}/junit.xml");
+        println!("wrote: {f}");
         fs::write(&f, &out).unwrap();
     }
 }

--- a/src/reporters/mod.rs
+++ b/src/reporters/mod.rs
@@ -6,6 +6,7 @@ pub use self::reporter::Reporter;
 use crate::data::ReporterConfig;
 use std::collections::HashMap;
 
+#[must_use]
 pub fn create_reporter<'a>(config: &HashMap<String, ReporterConfig>) -> Reporter<'a> {
     Reporter::new(config)
 }

--- a/src/reporters/reporter.rs
+++ b/src/reporters/reporter.rs
@@ -10,6 +10,7 @@ pub struct Reporter<'a> {
 unsafe impl<'a> Sync for Reporter<'a> {}
 
 impl<'a> Reporter<'a> {
+    #[must_use]
     pub fn new(reporters: &HashMap<String, ReporterConfig>) -> Self {
         Reporter {
             outputs: reporters
@@ -24,18 +25,18 @@ impl<'a> Reporter<'a> {
         }
     }
     pub fn start(&mut self, inter: &Interaction) {
-        self.outputs.iter_mut().for_each(|r| r.start(inter))
+        self.outputs.iter_mut().for_each(|r| r.start(inter));
     }
 
     pub fn report(&mut self, inter: &Interaction, check_result: &CheckResult) {
         self.outputs
             .iter_mut()
-            .for_each(|r| r.report(inter, check_result))
+            .for_each(|r| r.report(inter, check_result));
     }
 
     pub fn end(&mut self, interactions: &[Interaction], results: &[CheckResult]) {
         self.outputs
             .iter_mut()
-            .for_each(|r| r.end(interactions, results))
+            .for_each(|r| r.end(interactions, results));
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -29,7 +29,10 @@ impl RunOptions {
         if verbose {
             rc.insert("verbose".to_string(), "true".to_string());
         }
-        reporters.insert(reporter.unwrap_or_else(|| "console".to_string()), rc);
+        if let Some(reporter) = reporter {
+            reporters.insert(reporter, rc);
+        }
+
         RunOptions {
             sender,
             reporters,
@@ -96,8 +99,8 @@ pub struct RunnerReport {
 
 #[cfg(test)]
 mod tests {
-    use mockito::{mock, server_address};
     use super::*;
+    use mockito::{mock, server_address};
 
     const ITC_OK: &str = include_str!("fixtures/ok.yaml");
     const ITC_OK_THEN_ERROR: &str = include_str!("fixtures/ok-then-error.yaml");

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -29,6 +29,7 @@ impl RunOptions {
         if verbose {
             rc.insert("verbose".to_string(), "true".to_string());
         }
+
         if let Some(reporter) = reporter {
             reporters.insert(reporter, rc);
         }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -12,11 +12,12 @@ pub struct RunOptions {
 }
 impl Default for RunOptions {
     fn default() -> Self {
-        RunOptions::build(None, false, Some("console".into()), true)
+        Self::build(None, false, Some("console".into()), true)
     }
 }
 
 impl RunOptions {
+    #[must_use]
     pub fn build(
         dry_run: Option<String>,
         flip: bool,
@@ -34,13 +35,15 @@ impl RunOptions {
             reporters.insert(reporter, rc);
         }
 
-        RunOptions {
+        Self {
             sender,
-            reporters,
             flip,
+            reporters,
         }
     }
 }
+
+#[allow(clippy::module_name_repetitions)]
 pub struct SequenceRunner<'a> {
     sender: &'a dyn Sender,
     flip: bool,
@@ -53,13 +56,14 @@ impl<'a> SequenceRunner<'a> {
         flip: bool,
         reporters: HashMap<String, ReporterConfig>,
     ) -> Self {
-        SequenceRunner {
-            flip,
+        Self {
             sender,
+            flip,
             reporters,
         }
     }
 
+    #[must_use]
     pub fn from_opts(run_opts: &'a RunOptions) -> Self {
         SequenceRunner {
             flip: run_opts.flip,
@@ -93,6 +97,7 @@ impl<'a> SequenceRunner<'a> {
     }
 }
 
+#[allow(clippy::module_name_repetitions)]
 pub struct RunnerReport {
     pub ok: bool,
     pub results: Vec<CheckResult>,
@@ -114,21 +119,21 @@ mod tests {
 
         let sender = SenderBuilder::build(SenderOptions { dry_run: None });
         let runner = SequenceRunner::new(sender.as_ref(), flip, HashMap::new());
-        let report = runner.run(&mut ctx, &interactions);
-        return report;
+
+        runner.run(&mut ctx, &interactions)
     }
 
     #[test]
     fn test_runner_return_status_no_violations() {
         let report = execute_test(ITC_OK, false);
-        assert_eq!(report.ok, true);
+        assert!(report.ok);
     }
 
     #[test]
     fn test_runner_return_status_with_violations() {
         let _m1 = mock("GET", "/api/ok").with_status(400).create();
         let report = execute_test(ITC_OK, false);
-        assert_eq!(report.ok, false);
+        assert!(!report.ok);
     }
 
     #[test]
@@ -136,21 +141,21 @@ mod tests {
         let _m1 = mock("GET", "/api/ok").with_status(200).create();
         let _m2 = mock("GET", "/api/error").with_status(200).create();
         let report = execute_test(ITC_OK_THEN_ERROR, false);
-        assert_eq!(report.ok, false);
+        assert!(!report.ok);
     }
 
     #[test]
     fn test_runner_flip_return_status_no_violations() {
         let _m1 = mock("GET", "/api/ok").create();
         let report = execute_test(ITC_OK, true);
-        assert_eq!(report.ok, false);
+        assert!(!report.ok);
     }
 
     #[test]
     fn test_runner_flip_return_status_with_violations() {
         let _m1 = mock("GET", "/api/ok").with_status(400).create();
         let report = execute_test(ITC_OK, true);
-        assert_eq!(report.ok, true);
+        assert!(report.ok);
     }
 
     #[test]
@@ -158,6 +163,6 @@ mod tests {
         let _m1 = mock("GET", "/api/ok").with_status(200).create();
         let _m2 = mock("GET", "/api/error").with_status(200).create();
         let report = execute_test(ITC_OK_THEN_ERROR, true);
-        assert_eq!(report.ok, false);
+        assert!(!report.ok);
     }
 }

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -37,6 +37,7 @@ impl ReqwestSender {
     }
 }
 impl Sender for ReqwestSender {
+    #[allow(clippy::too_many_lines)]
     fn send(&self, inter: &Interaction) -> AnyResult<Response> {
         let request = &inter.request;
         // as_request -> RQRequest
@@ -63,8 +64,10 @@ impl Sender for ReqwestSender {
         if let Some(form) = &request.form {
             rq_builder = rq_builder.form(form);
         }
+
         if let Some(aws) = &request.aws_auth {
-            let credentials = AwsCredentials::new(aws.key.clone(), aws.secret.clone(), None, None);
+            let credentials =
+                AwsCredentials::new(aws.key.clone(), aws.secret.clone(), aws.token.clone(), None);
             let default_region = "us-east-1".to_string();
             let reg_str = aws.region.as_ref().unwrap_or(&default_region);
 
@@ -106,6 +109,10 @@ impl Sender for ReqwestSender {
                         .parse()
                         .unwrap(),
                 );
+            }
+
+            if let Some(token) = aws.token.as_ref() {
+                headers.insert("X-Amz-Security-Token", token.parse()?);
             }
 
             rq_builder = rq_builder.headers(headers);

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -1,20 +1,22 @@
 use crate::data::{Interaction, Response, Sender};
 use anyhow::Result as AnyResult;
-use log::*;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
-use rusoto_core::credential::AwsCredentials;
-use rusoto_core::signature::SignedRequest;
-use rusoto_core::Region;
+use rusoto_core::{credential::AwsCredentials, signature::SignedRequest, Region};
 
 use std::collections::HashMap;
 use std::str::FromStr;
 use std::time::Duration;
 
+#[allow(clippy::module_name_repetitions)]
 pub struct SenderOptions {
     pub dry_run: Option<String>,
 }
+
+#[allow(clippy::module_name_repetitions)]
 pub struct SenderBuilder {}
+
 impl SenderBuilder {
+    #[must_use]
     pub fn build(opts: SenderOptions) -> Box<dyn Sender> {
         let s: Box<dyn Sender> = match opts.dry_run {
             Some(examples_key) => Box::new(DrySender::new(&examples_key)),
@@ -24,15 +26,14 @@ impl SenderBuilder {
     }
 }
 
+#[derive(Default)]
+#[allow(clippy::module_name_repetitions)]
 pub struct ReqwestSender {}
-impl Default for ReqwestSender {
-    fn default() -> Self {
-        ReqwestSender {}
-    }
-}
+
 impl ReqwestSender {
+    #[must_use]
     pub fn new() -> Self {
-        ReqwestSender::default()
+        Self::default()
     }
 }
 impl Sender for ReqwestSender {
@@ -40,7 +41,7 @@ impl Sender for ReqwestSender {
         let request = &inter.request;
         // as_request -> RQRequest
         let uri = request.uri.clone();
-        debug!("uri with vars: {}", uri);
+        log::debug!("uri with vars: {}", uri);
         let client = reqwest::blocking::Client::builder()
             .timeout(Duration::from_millis(request.timeout_ms.unwrap_or(10000)))
             .build()
@@ -92,36 +93,34 @@ impl Sender for ReqwestSender {
 
             let rh = signed_request.headers();
 
-            [
+            for h in &[
                 "x-amz-content-sha256",
                 "x-amz-date",
                 "authorization",
                 "content-type",
                 "host",
-            ]
-            .iter()
-            .for_each(|h| {
+            ] {
                 headers.insert(
-                    h.to_string().parse::<HeaderName>().unwrap(),
+                    (*h).to_string().parse::<HeaderName>().unwrap(),
                     String::from_utf8_lossy(&rh.get(*h).unwrap()[0])
                         .parse()
                         .unwrap(),
                 );
-            });
+            }
 
             rq_builder = rq_builder.headers(headers);
         }
 
         if let Some(headers) = &request.headers {
             let mut headersmap = HeaderMap::new();
-            headers.iter().for_each(|(key, val)| {
-                val.iter().for_each(|v| {
+            for (key, val) in headers {
+                for v in val {
                     headersmap.insert(
                         key.to_lowercase().parse::<HeaderName>().unwrap(),
                         HeaderValue::from_str(v.clone().as_str()).unwrap(),
                     );
-                });
-            });
+                }
+            }
             rq_builder = rq_builder.headers(headersmap);
         };
 
@@ -158,13 +157,15 @@ impl Sender for ReqwestSender {
     }
 }
 
+#[allow(clippy::module_name_repetitions)]
 pub struct DrySender {
     example: String,
 }
 
 impl DrySender {
+    #[must_use]
     pub fn new(example: &str) -> Self {
-        DrySender {
+        Self {
             example: example.to_string(),
         }
     }
@@ -176,10 +177,9 @@ impl Sender for DrySender {
         if let Some(examples) = &inter.examples {
             if let Some(ex) = examples.get(&self.example) {
                 return Ok(ex.clone());
-            } else {
-                eprintln!("dry_send not found example: {}", self.example);
-                eprintln!("examples: {:?}", inter.examples);
             }
+            eprintln!("dry_send not found example: {}", self.example);
+            eprintln!("examples: {:?}", inter.examples);
         }
         // no example was given
         Ok(Response {


### PR DESCRIPTION
Implemented the feature to disable the reporter if none is provided. For more details, refer to this commit:
Commit link: https://github.com/SpectralOps/service-policy-kit/pull/2/commits/26f43d0b9dd54022a525b1e58485547cd28cc7b2

Also support optional fields and support session token in AWS. commit link [57543eb](https://github.com/SpectralOps/service-policy-kit/pull/2/commits/57543eb77935acde155fe35915091d159ab13093)

Following the update, I observed that the CI pipeline was inactive (likely due to the build workspace being disabled). I've reactivated the tests and addressed all encountered errors.
